### PR TITLE
Emergency shutdown improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,21 +71,21 @@ accounts gets compromised, it is possible to perform the emergency shutdown.
 
 ### Emergency shutdown
 
-To shut the bot down, any user can send the command `!SHUTDOWN` (exactly like this, in
-upper case with an exclamation mark and no other symbols/whitespaces/etc). Note that this
-will prevent the bot from accepting new requests (the script will exit and it won't resume
-until you restart it manually), but the child processes executed by previous requests won't
-be killed.
+To shut the bot down, user must send the command that they define in the config.py file.
+Unlike other commands, this command must exactly match the configured string
+(e.g. lowercase/capital letters mismatch are not allowed), except for the leading and trailing
+whitespaces (they are ignored). This will prevent the bot from accepting new requests
+(the bot will exit and it won't resume until you restart it manually), but the child processes
+started by previous requests won't be killed.
 
-Note that it is perfectly fine to stop the bot with a usual keyboard interrupt. The
-`!SHUTDOWN` command is intended for a case of emergency.
+It is also possible (and recommended) to configure the bot to accept the emergency shutdown
+command from all users, not just the admins. This is useful in case an admin looses access
+to their account to a malicious user.
 
-**WARNING:** by default, **EVERY USER**, not just the admins, is allowed to `!SHUTDOWN` the bot,
-in case you loose access to the admin(s) account(s). If you want to prevent such behavior, go
-to the `main.py` and uncomment the line that contains "with this line commented out ANYONE
-can shut the bot down". If you do so, the command will only remain available to the admins.
+Note that it is perfectly fine to stop the bot with a usual keyboard interrupt. The shutdown
+command is intended for a case of emergency.
 
-### After shutdown
+### After emergency shutdown
 
 Even if some commands were sent to the bot _after_ it was stopped, Telegram maintains (for a
 limited time) the queue of messages not yet processed by the bot. So, if when starting the bot
@@ -93,12 +93,12 @@ next time, the malefactor remains in the admins list (e.g. if a real admin accou
 compromised but then restored), the bot _might_ still receive the malicious commands, even if
 the corresponding messages were deleted.
 
-Besides, it is possible that the `!SHUTDOWN` command itself is not marked as processed
+Besides, it is possible that the emergency shutdown command itself is not marked as processed
 (because the bot tries to stop itself ASAP), so it might receive this command again when
 runned next time (and, therefore, exit immediately).
 
-Thus, it is recommended to run `after_shutdown.py` after you `!SHUTDOWN` the bot before
-you restart it again. It will print all the queued messages (if any) and new incoming
+Thus, it is recommended to run `after_shutdown.py` after emergency shutdown of the bot before
+it is restarted. It will print all the queued messages (if any) and new incoming
 messages, while it is running, clearing the queue on the Telegram side. After that just stop
 this process and run `main.py` as usually.
 

--- a/after_shutdown.py
+++ b/after_shutdown.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Use this script to clear Telegram's cache of messages not yet processed by the bot.
-# This can be useful after `!SHUTDOWN` if malefactor has sent messages with commands
+# This can be useful after emergency shutdown if malefactor has sent messages with commands
 # after you stopped the bot.
 
 import telebot

--- a/config.py.example
+++ b/config.py.example
@@ -14,3 +14,21 @@ admins_ids = [123, 456]  # List of Telegram user identifiers (integers). Find vi
 # is reread) and then send `/start` command in Telegram (so that the keyboard on your Telegram client
 # is updated)
 quick_access_cmds = [['/key space', '/type Hello, World!'], ['/type This will appear on second line']]
+
+# `emergency_shutdown_command` is a string that can be used for emergency shutdown, intended for
+# the scenario when a malicious user gets access to one of the admins' accounts.
+# If the bot receives a message with this text, it terminates immediately. Notice, that the message
+# text must exactly match the string (including lowercase/capital letters and special symbols),
+# except for the leading and trailing whitespaces (they will be ignored).
+#
+# For example, if the command is set to '/A b123C ', message ' /A b123C' will terminate the bot,
+# while 'A b123C', '/A b123c', or '/Ab123C' won't.
+emergency_shutdown_command = 'YOUR_COMMAND_HERE'
+
+# If `emergency_shutdown_public` is `True`, then **any user**, not just the admins, will be allowed
+# to use the `emergency_shutdown_command`. It is useful in case you loose access to your admin account
+# while the intruder is still there: with this enabled you will be able to terminate the bot from any
+# other account.
+#
+# It is recommended to leave this enabled and keep the emergency shutdown command in secret.
+emergency_shutdown_public = True


### PR DESCRIPTION
- Instead of `!SHUTDOWN`, use a command defined in the config file for emergency bot shutdown.
- Allow user to configure whether the emergency shutdown functionality should be public or available to admins only.

Fixes #3