### PR TITLE
Add rimokon_main.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Telegram bot for simple remote control of the device it is running on.
    Use [@BotFather](https://t.me/BotFather) to acquire a Telegram bot token.
 
 
--  Run the bot as a python package: `python3 -m Rimokon` or, from another directory,
-   `python3 -m Path.To.Rimokon.With.Dot.Delimiters`
+-  Run the bot as a python package: `python3 rimokon_main.py`
 
 
 ## Plugins, actions, and aliases

--- a/Rimokon/__main__.py
+++ b/Rimokon/__main__.py
@@ -86,7 +86,7 @@ def run_command(message):
         Thread(target=action_func, args=(bot, message, command_rest)).start()
 
 
-if __name__ == "__main__":
+def main():
     while True:
         try:
             bot.polling(non_stop=True)
@@ -97,3 +97,7 @@ if __name__ == "__main__":
             print(format_exc(), file=stderr)
             sleep(3)
             print("Restarted\n", file=stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/rimokon_main.py
+++ b/rimokon_main.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+if __name__ == "__main__":
+    from Rimokon.__main__ import main
+    main()
+else:
+    raise ImportError("Import the Rimokon package directly, not through rimokon_main.py")


### PR DESCRIPTION
Allow a more convenient way to run Rimokon from an arbitrary workdir