### PR TITLE
plugins/screenshot: Add `grim` as an alternative to `PIL`

### DIFF
--- a/Rimokon/config.py.example
+++ b/Rimokon/config.py.example
@@ -44,7 +44,7 @@ emergency_shutdown_is_public = True
 # dictionaries.
 
 from .plugins.run_rawrun_shell import run, rawrun, shell, run_parsed_command
-from .plugins.screenshot import screen, screenf
+from .plugins.screenshot import screen_as_photo_with, screen_as_file_with, with_pil
 
 # This dictionary specifies a mapping from action name (i.e. the command that the user will use) to the
 # action function.
@@ -52,8 +52,8 @@ actions = {
     'run': run,
     'rawrun': rawrun,
     'shell': shell,
-    'screen': screen,
-    'screenf': screenf
+    'screen': screen_as_photo_with(with_pil),
+    'screenf': screen_as_file_with(with_pil),
 }
 
 # Aliases complement the set of actions. Here users can specify their commands that are based on the

--- a/Rimokon/plugins/screenshot.py
+++ b/Rimokon/plugins/screenshot.py
@@ -1,35 +1,93 @@
 from io import BytesIO
-from typing import Optional
+from typing import Callable, IO, Optional
 
-from PIL import ImageGrab
 import telebot
 
 from .plugin_helpers import help_description
 
 
-__all__ = ['screen', 'screenf']
+__all__ = [
+    'with_pil',
+    'with_grim',
+    'screen_as_photo_with',
+    'screen_as_file_with',
+]
 
 
-def take_screenshot_or_complain_to(bot: telebot.TeleBot, message: telebot.types.Message) -> Optional[BytesIO]:
-    try:
-        screenshot = ImageGrab.grab()
-    except OSError as e:
-        bot.reply_to(message, f"Error: your machine doesn't seem to support this:\n{e}")
-        return
+def with_pil() -> BytesIO:
+    """
+    Takes a screenshot using the `PIL` library.
+
+    This function is intended to be given as an argument to functions
+    such as `screen_as_photo_with`, `screen_as_file_with`.
+    """
+
+    from PIL import ImageGrab
+
+    screenshot = ImageGrab.grab()
     img = BytesIO()
-    img.name = 'i.png'  # Telegram doesn't like untitled files
+    img.name = 'pil.png'  # Telegram doesn't like unnamed files
     screenshot.save(img, 'PNG')
     img.seek(0)
     return img
 
-@help_description("Take a screenshot and send as a photo")
-def screen(bot: telebot.TeleBot, message: telebot.types.Message, _: str) -> None:
-    img = take_screenshot_or_complain_to(bot, message)
-    if img:
-        bot.send_photo(message.chat.id, img, reply_to_message_id=message.message_id)
+def with_grim() -> BytesIO:
+    """
+    Takes a screenshot using the `grim` tool.
 
-@help_description("Take a screenshot and send as a document")
-def screenf(bot: telebot.TeleBot, message: telebot.types.Message, _: str) -> None:
-    img = take_screenshot_or_complain_to(bot, message)
-    if img:
-        bot.send_document(message.chat.id, img, reply_to_message_id=message.message_id)
+    This function is intended to be given as an argument to functions
+    such as `screen_as_photo_with`, `screen_as_file_with`.
+    """
+
+    import subprocess
+
+    grim = subprocess.run(['grim', '-t', 'png', '/proc/self/fd/1'], stdout=subprocess.PIPE)
+    img = BytesIO()
+    img.name = 'grim.png'  # Telegram doesn't like unnamed files
+    img.write(grim.stdout)
+    img.seek(0)
+    return img
+
+def take_screenshot_with_or_complain_to(
+    screenshot_method: Callable[[], IO[bytes]],
+    bot: telebot.TeleBot,
+    message: telebot.types.Message
+) -> Optional[IO[bytes]]:
+    try:
+        screenshot = screenshot_method()
+    except Exception as e:
+        bot.reply_to(message, f"Error: your machine doesn't seem to support this:\n{e}")
+    else:
+        return screenshot
+
+def screen_as_photo_with(
+    screenshot_method: Callable[[], IO[bytes]]
+) -> Callable[[telebot.TeleBot, telebot.types.Message, str], None]:
+    """
+    Given a screenshot method (e.g., `with_pil` or `with_grim`),
+    returns an action function that takes a screenshot and sends it as a photo.
+    """
+
+    @help_description("Take a screenshot and send as a photo")
+    def screen(bot: telebot.TeleBot, message: telebot.types.Message, _: str) -> None:
+        img = take_screenshot_with_or_complain_to(screenshot_method, bot, message)
+        if img:
+            bot.send_photo(message.chat.id, img, reply_to_message_id=message.message_id)
+
+    return screen
+
+def screen_as_file_with(
+    screenshot_method: Callable[[], IO[bytes]]
+) -> Callable[[telebot.TeleBot, telebot.types.Message, str], None]:
+    """
+    Given a screenshot method (e.g., `with_pil` or `with_grim`),
+    returns an action function that takes a screenshot and sends it as a file (document).
+    """
+
+    @help_description("Take a screenshot and send as a document")
+    def screenf(bot: telebot.TeleBot, message: telebot.types.Message, _: str) -> None:
+        img = take_screenshot_with_or_complain_to(screenshot_method, bot, message)
+        if img:
+            bot.send_document(message.chat.id, img, reply_to_message_id=message.message_id)
+
+    return screenf


### PR DESCRIPTION
Extend the plugin to support the `grim` screenshotting utility in addition to PIL's `ImageGrab`. It's up to the user to select the screenshotting method in their config.